### PR TITLE
Fix ER sampling for undirected graphs

### DIFF
--- a/clrs/_src/samplers.py
+++ b/clrs/_src/samplers.py
@@ -149,7 +149,8 @@ class Sampler(abc.ABC):
 
     mat = self._rng.binomial(1, p, size=(nb_nodes, nb_nodes))
     if not directed:
-      mat *= np.transpose(mat)
+      mat = np.triu(mat)
+      mat = mat | np.transpose(mat)
     elif acyclic:
       mat = np.triu(mat, k=1)
       p = self._rng.permutation(nb_nodes)  # To allow nontrivial solutions


### PR DESCRIPTION
Hi, I think there is a small issue in the implementation of ER sampling for undirected graphs. With current implementation, each edge is present if both of its directions are present, whose probability would be `p^2`. Also for self-loops, the probability is `p`. To make it more consistent with ER graph generation, I think each undirected edge should be sampled with probability `p` (instead of `p^2`).